### PR TITLE
docs: add gitcgr code graph badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # gulls
 
+[![gitcgr](https://gitcgr.com/badge/gulls-microlensing/gulls.svg)](https://gitcgr.com/gulls-microlensing/gulls)
+
 A microlensing simulator optimized for space-based microlensing surveys.
 
 Warning: This repository is not yet fully operational due to our


### PR DESCRIPTION
Adds a [gitcgr](https://gitcgr.com) badge to the README showing code graph statistics for this repository.

**Badge preview:**

[![gitcgr](https://gitcgr.com/badge/gulls-microlensing/gulls.svg)](https://gitcgr.com/gulls-microlensing/gulls)

---

[gitcgr.com](https://gitcgr.com) visualizes any GitHub repo as an interactive code graph — just change `hub` to `cgr` in the URL.

Generated automatically by [gitcgr](https://gitcgr.com).